### PR TITLE
Switch from Poetry to setuptools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
       - name: Setup python for ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: poetry install --only=dev
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[cli]
+          python -m pip install bip32utils pytest black isort
       - name: Run style check
-        run: poetry run make style_check
+        run: make style_check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,14 @@ jobs:
         python-version: ['3.7.13', '3.8.12', '3.9.12', '3.10.4']
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
       - name: Setup python for ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: poetry install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+          python -m pip install bip32utils pytest
       - name: Run tests for Python-${{ matrix.python-version }} with ${{ matrix.os }}
-        run: poetry run pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pycache__
 
 *.swp
 *.py[co]
-poetry.lock

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
 PYTHON=python3
-POETRY=poetry
 
 
 build:
-	$(POETRY) build
+	$(PYTHON) -m build
 
 install:
-	$(POETRY) install
+	$(PYTHON) -m pip install .
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 

--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,15 @@ With pip from PyPI:
 
 From local checkout for development:
 
-Install the [Poetry](https://python-poetry.org/) tool, checkout
-`python-shamir-mnemonic` from git, and enter the poetry shell:
+Create a virtual environment and install the package from a local checkout:
 
 .. code-block:: console
 
-    $ pip3 install poetry
     $ git clone https://github.com/trezor/python-shamir-mnemonic
     $ cd python-shamir-mnemonic
-    $ poetry install
-    $ poetry shell
+    $ python3 -m venv venv
+    $ . venv/bin/activate
+    (venv) $ pip install -e .[cli]
 
 CLI usage
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,3 @@
-[tool.poetry]
-name = "shamir-mnemonic"
-version = "0.3.1"
-description = "SLIP-39 Shamir Mnemonics"
-authors = ["Trezor <info@trezor.io>"]
-license = "MIT"
-readme = [
-    "README.rst",
-    "CHANGELOG.rst",
-]
-
-[tool.poetry.dependencies]
-python = ">=3.6,<4.0"
-dataclasses = { version = "*", python = "<=3.6" }
-click = { version = ">=7,<9", optional = true }
-
-[tool.poetry.group.dev.dependencies]
-bip32utils = "^0.3.post4"
-pytest = "*"
-black = ">=20"
-isort = "^5"
-
-[tool.poetry.extras]
-cli = ["click"]
-
-[tool.poetry.scripts]
-shamir = "shamir_mnemonic.cli:cli"
-
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import find_packages, setup
+
+with open("README.rst", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="shamir-mnemonic",
+    version="0.3.1",
+    description="SLIP-39 Shamir Mnemonics",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    author="Trezor",
+    author_email="info@trezor.io",
+    license="MIT",
+    packages=find_packages(),
+    include_package_data=True,
+    package_data={"shamir_mnemonic": ["wordlist.txt"]},
+    python_requires=">=3.6,<4.0",
+    install_requires=[
+        "dataclasses; python_version<'3.7'",
+    ],
+    extras_require={
+        "cli": ["click>=7,<9"],
+    },
+    entry_points={
+        "console_scripts": ["shamir=shamir_mnemonic.cli:cli"],
+    },
+)

--- a/shamir_mnemonic/constants.py
+++ b/shamir_mnemonic/constants.py
@@ -3,7 +3,7 @@ from .utils import bits_to_words
 RADIX_BITS = 10
 """The length of the radix in bits."""
 
-RADIX = 2 ** RADIX_BITS
+RADIX = 2**RADIX_BITS
 """The number of words in the wordlist."""
 
 ID_LENGTH_BITS = 15


### PR DESCRIPTION
## Summary
- switch build system to setuptools
- add `setup.py` with package metadata and CLI entry point
- update Makefile to use `python -m build` and pip install
- update README with virtualenv instructions
- update GitHub workflows for pip install
- run formatters and fix Makefile tabs

## Testing
- `make style_check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688aaf3369cc83228375354a21dcd1fb